### PR TITLE
Adding candidate for sqlpkg.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ See [`docs.md`](./docs.md) for a full API reference.
 | Ruby           | `gem install sqlite-regex`                                     | ![Gem](https://img.shields.io/gem/v/sqlite-regex?color=red&logo=rubygems&logoColor=white)                                                                                                     |
 | Github Release |                                                                | ![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/asg017/sqlite-regex?color=lightgrey&include_prereleases&label=Github+release&logo=github)                       |
 | Rust           | `cargo add sqlite-regex`                                       | [![Crates.io](https://img.shields.io/crates/v/sqlite-regex?logo=rust)](https://crates.io/crates/sqlite-regex)                                                                                 |
+| Sqlite         | `sqlpkg install asg017/regex`                                  | [![sqlpkg CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fasg017%2Fsqlite-regex%2Freleases%2Flatest&query=name&logo=sqlite&label=sqlpkg%20CLI&color=85cff3)](https://sqlpkg.org/) |
 
 <!--
 | Elixir         | [`hex.pm/packages/sqlite_regex`](https://hex.pm/packages/sqlite_regex) | [![Hex.pm](https://img.shields.io/hexpm/v/sqlite_regex?color=purple&logo=elixir)](https://hex.pm/packages/sqlite_regex)                                                                       |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # sqlite-regex
 
 A fast and performant SQLite extension for regular expressions. Based on [`sqlite-loadable-rs`](https://github.com/asg017/sqlite-loadable-rs), and the [regex crate](https://crates.io/crates/regex).
@@ -124,7 +125,7 @@ See [`docs.md`](./docs.md) for a full API reference.
 | Ruby           | `gem install sqlite-regex`                                     | ![Gem](https://img.shields.io/gem/v/sqlite-regex?color=red&logo=rubygems&logoColor=white)                                                                                                     |
 | Github Release |                                                                | ![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/asg017/sqlite-regex?color=lightgrey&include_prereleases&label=Github+release&logo=github)                       |
 | Rust           | `cargo add sqlite-regex`                                       | [![Crates.io](https://img.shields.io/crates/v/sqlite-regex?logo=rust)](https://crates.io/crates/sqlite-regex)                                                                                 |
-| Sqlite         | `sqlpkg install asg017/regex`                                  | [![sqlpkg CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fasg017%2Fsqlite-regex%2Freleases%2Flatest&query=name&logo=sqlite&label=sqlpkg%20CLI&color=85cff3)](https://sqlpkg.org/) |
+| Sqlite         | `sqlpkg install asg017/regex`                                  | [![sqlpkg CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fasg017%2Fsqlite-regex%2Freleases%2Flatest&query=name&logo=sqlite&label=sqlpkg%20CLI&color=%2385cff3)](https://sqlpkg.org/)  |
 
 <!--
 | Elixir         | [`hex.pm/packages/sqlite_regex`](https://hex.pm/packages/sqlite_regex) | [![Hex.pm](https://img.shields.io/hexpm/v/sqlite_regex?color=purple&logo=elixir)](https://hex.pm/packages/sqlite_regex)                                                                       |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ See [`docs.md`](./docs.md) for a full API reference.
 | Ruby           | `gem install sqlite-regex`                                     | ![Gem](https://img.shields.io/gem/v/sqlite-regex?color=red&logo=rubygems&logoColor=white)                                                                                                     |
 | Github Release |                                                                | ![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/asg017/sqlite-regex?color=lightgrey&include_prereleases&label=Github+release&logo=github)                       |
 | Rust           | `cargo add sqlite-regex`                                       | [![Crates.io](https://img.shields.io/crates/v/sqlite-regex?logo=rust)](https://crates.io/crates/sqlite-regex)                                                                                 |
-| Sqlite         | `sqlpkg install asg017/regex`                                  | [![sqlpkg CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fasg017%2Fsqlite-regex%2Freleases%2Flatest&query=name&logo=sqlite&label=sqlpkg%20CLI&color=%2385cff3)](https://sqlpkg.org/)  |
+| Sqlite         | `sqlpkg install asg017/regex`                                  | [![sqlpkg CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmikeschinkel%2Fsqlite-regex%2Fmain%2Fsqlpkg.json&query=version&logo=sqlite&label=sqlpkg%20CLI&color=%2385cff3)](https://sqlpkg.org/)  |
+
 
 <!--
 | Elixir         | [`hex.pm/packages/sqlite_regex`](https://hex.pm/packages/sqlite_regex) | [![Hex.pm](https://img.shields.io/hexpm/v/sqlite_regex?color=purple&logo=elixir)](https://hex.pm/packages/sqlite_regex)                                                                       |

--- a/sqlpkg.json
+++ b/sqlpkg.json
@@ -1,13 +1,12 @@
 {
    "owner": "asg017",
-   "name": "sqlite-regex",
+   "name": "regex",
    "version": "v0.2.3",
    "repository": "https://github.com/asg017/sqlite-regex",
    "authors": ["Alex Garcia"],
    "license": "MIT",
    "description": "A fast regular expression SQLite extension, written in Rust.",
-   "keywords": ["sqlite-regex"],
-   "symbols": ["regexp"],
+   "keywords": ["sqlite","regex"],
    "assets": {
       "files": {
          "darwin-amd64": "sqlite-regex-{version}-loadable-macos-x86_64.tar.gz",

--- a/sqlpkg.json
+++ b/sqlpkg.json
@@ -1,0 +1,19 @@
+{
+   "owner": "asg017",
+   "name": "sqlite-regex",
+   "version": "v0.2.3",
+   "repository": "https://github.com/asg017/sqlite-regex",
+   "authors": ["Alex Garcia"],
+   "license": "MIT",
+   "description": "A fast regular expression SQLite extension, written in Rust.",
+   "keywords": ["sqlite-regex"],
+   "symbols": ["regexp"],
+   "assets": {
+      "files": {
+         "darwin-amd64": "sqlite-regex-{version}-loadable-macos-x86_64.tar.gz",
+         "darwin-arm64": "sqlite-regex-{version}-loadable-macos-aarch64.tar.gz",
+         "linux-amd64": "sqlite-regex-{version}-loadable-linux-x86_64.tar.gz",
+         "windows-amd64": "sqlite-regex-{version}-loadable-windows-x86_64.tar.gz"
+      }
+   }
+}

--- a/sqlpkg.json
+++ b/sqlpkg.json
@@ -1,18 +1,37 @@
 {
-   "owner": "asg017",
-   "name": "regex",
-   "version": "v0.2.3",
-   "repository": "https://github.com/asg017/sqlite-regex",
-   "authors": ["Alex Garcia"],
-   "license": "MIT",
-   "description": "A fast regular expression SQLite extension, written in Rust.",
-   "keywords": ["sqlite","regex"],
-   "assets": {
-      "files": {
-         "darwin-amd64": "sqlite-regex-{version}-loadable-macos-x86_64.tar.gz",
-         "darwin-arm64": "sqlite-regex-{version}-loadable-macos-aarch64.tar.gz",
-         "linux-amd64": "sqlite-regex-{version}-loadable-linux-x86_64.tar.gz",
-         "windows-amd64": "sqlite-regex-{version}-loadable-windows-x86_64.tar.gz"
-      }
-   }
+    "owner": "asg017",
+    "name": "regex",
+    "version": "v0.2.3",
+    "repository": "https://github.com/asg017/sqlite-regex",
+    "authors": ["Alex Garcia"],
+    "license": "MIT",
+    "description": "Fast and performant regular expressions.",
+    "keywords": ["sqlite-regex"],
+    "symbols": [
+        "regex_capture",
+        "regex_captures",
+        "regex_debug",
+        "regex_find_all",
+        "regex_find",
+        "regex_print",
+        "regex_replace_all",
+        "regex_replace",
+        "regex_split",
+        "regex_valid",
+        "regex_version",
+        "regex",
+        "regexp",
+        "regexset_is_match",
+        "regexset_matches",
+        "regexset_print",
+        "regexset"
+    ],
+    "assets": {
+        "files": {
+            "darwin-amd64": "sqlite-regex-{version}-loadable-macos-x86_64.tar.gz",
+            "darwin-arm64": "sqlite-regex-{version}-loadable-macos-aarch64.tar.gz",
+            "linux-amd64": "sqlite-regex-{version}-loadable-linux-x86_64.tar.gz",
+            "windows-amd64": "sqlite-regex-{version}-loadable-windows-x86_64.zip"
+        }
+    }
 }


### PR DESCRIPTION
Here is a candidate `sqlpkg.json`  for you to consider adding to `sqlite-reqexp`.

Addresses #16.